### PR TITLE
Fix async race condition between check of isOpen and making a request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.4+1
+
+* Fix race condition in gRPC client between `http2Connection.isOpen` and
+  `http2Connection.makeRequest`.
+
+* Delay http/2 connection dialer by 20 ms to give client enough time to receive
+  server settings.
+
 ## 0.4.4
 
 * Improve output logging when memcache connections fail.

--- a/lib/src/grpc_api_impl/grpc.dart
+++ b/lib/src/grpc_api_impl/grpc.dart
@@ -143,8 +143,10 @@ class Client {
       _trailersHeader,
       _compressionHeader,
       _userAgentHeader,
-      _cachedAuthorizationHeader,
     ];
+    if (_cachedAuthorizationHeader != null) {
+      headers.add(_cachedAuthorizationHeader);
+    }
 
     // We remember the connection this RPC call is using since other
     // concurrent calls might change `this._connection` while this method
@@ -302,7 +304,7 @@ class Dialer {
   // possibly running over the max-concurrent-streams setting the server
   // is sending to the client (which will cause the server to terminate
   // the connection).
-  static const Duration estimatedRTT = const Duration(milliseconds: 20);
+  static const Duration _estimatedRTT = const Duration(milliseconds: 20);
 
   final Uri endpoint;
 
@@ -345,7 +347,7 @@ class Dialer {
         if (socket.selectedProtocol == 'h2') {
           final connection =
               new http2.ClientTransportConnection.viaStreams(socket, socket);
-          await new Future.delayed(estimatedRTT);
+          await new Future.delayed(_estimatedRTT);
           _completer.complete(connection);
           _completer = null;
         } else {
@@ -366,7 +368,7 @@ class Dialer {
         socket.setOption(SocketOption.TCP_NODELAY, true);
         final connection =
             new http2.ClientTransportConnection.viaStreams(socket, socket);
-        await new Future.delayed(estimatedRTT);
+        await new Future.delayed(_estimatedRTT);
         _completer.complete(connection);
         _completer = null;
       } catch (error) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine
 environment:
-  sdk: '>=1.22.0 <2.0.0'
+  sdk: '>=1.22.0 <3.0.0'
 dependencies:
   fixnum: '>=0.9.0 <0.11.0'
   gcloud: '>=0.5.0 <0.6.0'
@@ -18,4 +18,4 @@ dependencies:
   protobuf: '^0.8.0'
   stack_trace: '^1.9.0'
 dev_dependencies:
-  test: '^0.12.18+1'
+  test: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.4.4
+version: 0.4.4+1
 author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine


### PR DESCRIPTION
Checking of `connection.isOpen` and invoking `connection.makeRequest`
must be done synchronously.  If there is an `await` in-between, the
connection could have been closed, run out of streams, ...

This CL also introduces a slight delay of 20 ms after connection setup
to allow our client to receive the servers http/2 Settings, which
includes a max-concurrent-streams change of "infinite -> 100".  Without
this delay, we might issue too many RPCs on a connection, just to
receive the limit later and a termination of all streams by the server.