### PR TITLE
Added helper for writing cronjob handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.1
 
- * Added a helper method for determining if a request originates from the
-   AppEngine cronjob scheduler.
+ * Added `isCronJonRequest` as a helper method for determining if a request
+   originates from the AppEngine cronjob scheduler.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+ * Added a helper method for determining if a request originates from the
+   AppEngine cronjob scheduler.
+
 ## 0.6.0
 
 **Breaking changes:**

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -69,7 +69,7 @@ Future runAppEngine(void handler(HttpRequest request),
  * Returns `true`, if the incoming request is an AppEngine cron job request.
  * 
  * To schedule cron jobs for your application, you must create a `cron.yaml`
- * file in the project root along side your `app.yaml`. The following is an
+ * file in the project root alongside your `app.yaml`. The following is an
  * example of such a `cron.yaml` file:
  * ```yaml
  * cron:
@@ -83,8 +83,11 @@ Future runAppEngine(void handler(HttpRequest request),
  * an HTTP request to the `default` service for the resource
  * `/tasks/database-cleanup`. In practice anyone can instigate such a request,
  * but AppEngine will send the request from `'10.0.0.1'` and include a special
- * header. The [isCronJobRequest] will validate the origin of the [request] to
- * ensure that it does indeed originate from AppEngines cron job scheduler. 
+ * header. This function will validate the origin of the [request] to
+ * ensure that it does indeed originate from
+ * [AppEngine's cron job scheduler][1]. 
+ * 
+ * [1]: https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml#validating_cron_requests
  */
 bool isCronJobRequest(HttpRequest request) {
   return request.headers['X-Appengine-Cron'].contains('true') &&

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -66,6 +66,32 @@ Future runAppEngine(void handler(HttpRequest request),
 }
 
 /**
+ * Returns `true`, if the incoming request is an AppEngine cron job request.
+ * 
+ * To schedule cron jobs for your application, you must create a `cron.yaml`
+ * file in the project root along side your `app.yaml`. The following is an
+ * example of such a `cron.yaml` file:
+ * ```yaml
+ * cron:
+ * - description: 'daily database cleanup job'
+ *   url: '/tasks/database-cleanup'
+ *   schedule: 'every 24 hours'
+ *   target: 'default'
+ * ```
+ * 
+ * When the cronjob from the example above is triggered AppEngine will send
+ * an HTTP request to the `default` service for the resource
+ * `/tasks/database-cleanup`. In practice anyone can instigate such a request,
+ * but AppEngine will send the request from `'10.0.0.1'` and include a special
+ * header. The [isCronJobRequest] will validate the origin of the [request] to
+ * ensure that it does indeed originate from AppEngines cron job scheduler. 
+ */
+bool isCronJobRequest(HttpRequest request) {
+  return request.headers['X-Appengine-Cron'].contains('true') &&
+      request.connectionInfo.remoteAddress == InternetAddress('10.0.0.1');
+}
+
+/**
  * Runs [callback] inside a new service scope with appengine services added.
  *
  * The services available to `callback` are all non-request specific appengine

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.6.0
+version: 0.6.1
 author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine


### PR DESCRIPTION
AppEngine initiates cronjobs as HTTP request from a special IP
and featuring special headers which allows the application to
determine if a request originates from the AppEngine cronjob
scheduler.