### PR TITLE
Add onAcceptingConnections callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+ * Add `onAcceptingConnections` callback to `runAppEngine()`
+
 ## 0.7.2
 
  * Update the generated protobufs.
@@ -18,7 +22,7 @@
 ## 0.6.0
 
 **Breaking changes:**
- * Removed poorly documented assets support with broken tests.  
+ * Removed poorly documented assets support with broken tests.
  * Removed memcache as the service was never made it past alpha.
 
 Users of memcache should consider using
@@ -57,7 +61,7 @@ without the logic that this package used to contain.
 ## 0.4.3+1
 
 * When logging requests, the `appengine.googleapis.com/trace_id` label
-  is populated. 
+  is populated.
 
 ## 0.4.3
 
@@ -66,7 +70,7 @@ without the logic that this package used to contain.
   * `referrer`
   * `traceId` via the `X-Cloud-Trace-Context` request header.
 
-* The `appengine.googleapis.com/instance_name` label is also populated for 
+* The `appengine.googleapis.com/instance_name` label is also populated for
   all log entries.
 
 * `traceId` was also added to the `ClientContext` class.

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -48,7 +48,9 @@ const Symbol _APPENGINE_CONTEXT = #appengine.context;
 /// servers. Connections can be distributed over multiple isolates this way.
 ///
 /// The optional [onAcceptingConnections] callback, if provided, will be
-/// notified when the server is accepting connections on [port].
+/// notified when the server is accepting connections on [port]. The `address`
+/// and `port` arguments that are passed to the callback specify the address
+/// and port that the server is listening on.
 ///
 /// The returned `Future` will complete when the HTTP server has been shutdown
 /// and is no longer serving requests.
@@ -57,7 +59,7 @@ Future runAppEngine(
   Function onError,
   int port = 8080,
   bool shared = false,
-  void onAcceptingConnections(),
+  void onAcceptingConnections(InternetAddress address, int port),
 }) {
   var errorHandler;
   if (onError != null) {

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -41,9 +41,9 @@ const Symbol _APPENGINE_CONTEXT = #appengine.context;
 /// You can provide a [port] if you want to run the HTTP server on a different
 /// port than the `8080` default.
 ///
-/// The optional argument [shared] argument specifies whether additional
-/// AppEngine servers can bind to the same `port`. If `shared` is `true` and
-/// more AppEngine servers from this isolate or other isolates are bound to the
+/// The optional [shared] argument specifies whether additional AppEngine
+/// servers can bind to the same `port`. If `shared` is `true` and more
+/// AppEngine servers from this isolate or other isolates are bound to the
 /// port, then the incoming connections will be distributed among all the bound
 /// servers. Connections can be distributed over multiple isolates this way.
 ///

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -27,7 +27,7 @@ const Symbol _APPENGINE_CONTEXT = #appengine.context;
 /// The [handler] will be executed inside a new request handler zone for every
 /// new request. This will isolate different requests from each other.
 /// Each [handler] has access to a [ClientContext] using the [context] getter
-/// in this library. It can be used to access appengine services, e.g. 
+/// in this library. It can be used to access appengine services, e.g.
 /// datastore.
 ///
 /// In case an uncaught error occurs inside the request handler, the request
@@ -41,10 +41,24 @@ const Symbol _APPENGINE_CONTEXT = #appengine.context;
 /// You can provide a [port] if you want to run the HTTP server on a different
 /// port than the `8080` default.
 ///
+/// The optional argument [shared] argument specifies whether additional
+/// AppEngine servers can bind to the same `port`. If `shared` is `true` and
+/// more AppEngine servers from this isolate or other isolates are bound to the
+/// port, then the incoming connections will be distributed among all the bound
+/// servers. Connections can be distributed over multiple isolates this way.
+///
+/// The optional [onAcceptingConnections] callback, if provided, will be
+/// notified when the server is accepting connections on [port].
+///
 /// The returned `Future` will complete when the HTTP server has been shutdown
 /// and is no longer serving requests.
-Future runAppEngine(void handler(HttpRequest request),
-    {Function onError, int port = 8080, bool shared = false}) {
+Future runAppEngine(
+  void handler(HttpRequest request), {
+  Function onError,
+  int port = 8080,
+  bool shared = false,
+  void onAcceptingConnections(),
+}) {
   var errorHandler;
   if (onError != null) {
     if (onError is ZoneUnaryCallback) {
@@ -61,7 +75,10 @@ Future runAppEngine(void handler(HttpRequest request),
       (HttpRequest request, ClientContext context) {
     ss.register(_APPENGINE_CONTEXT, context);
     handler(request);
-  }, errorHandler, port: port, shared: shared);
+  }, errorHandler,
+      port: port,
+      shared: shared,
+      onAcceptingConnections: onAcceptingConnections);
 }
 
 /// Returns `true`, if the incoming request is an AppEngine cron job request.

--- a/lib/src/appengine_internal.dart
+++ b/lib/src/appengine_internal.dart
@@ -41,9 +41,13 @@ Future withAppEngineServices(Future callback()) =>
 ///
 /// The given request [handler] is run inside a new service scope and has all
 /// AppEngine services available within that scope.
-Future runAppEngine(void handler(HttpRequest request, ClientContext context),
-    void onError(Object e, StackTrace s),
-    {int port = 8080, bool shared = false, void onAcceptingConnections()}) {
+Future runAppEngine(
+  void handler(HttpRequest request, ClientContext context),
+  void onError(Object e, StackTrace s), {
+  int port = 8080,
+  bool shared = false,
+  void onAcceptingConnections(InternetAddress address, int port),
+}) {
   return _withAppEngineServicesInternal((ContextRegistry contextRegistry) {
     final appengineServer = AppEngineHttpServer(contextRegistry,
         port: port, shared: shared)

--- a/lib/src/appengine_internal.dart
+++ b/lib/src/appengine_internal.dart
@@ -43,7 +43,7 @@ Future withAppEngineServices(Future callback()) =>
 /// AppEngine services available within that scope.
 Future runAppEngine(void handler(HttpRequest request, ClientContext context),
     void onError(Object e, StackTrace s),
-    {int port = 8080, bool shared = false}) {
+    {int port = 8080, bool shared = false, void onAcceptingConnections()}) {
   return _withAppEngineServicesInternal((ContextRegistry contextRegistry) {
     final appengineServer = AppEngineHttpServer(contextRegistry,
         port: port, shared: shared)
@@ -87,7 +87,7 @@ Future runAppEngine(void handler(HttpRequest request, ClientContext context),
             }
           });
         });
-      });
+      }, onAcceptingConnections: onAcceptingConnections);
     return appengineServer.done;
   });
 }

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -36,7 +36,10 @@ class AppEngineHttpServer {
 
   Future get done => _shutdownCompleter.future;
 
-  void run(applicationHandler(HttpRequest request, ClientContext context)) {
+  void run(
+    applicationHandler(HttpRequest request, ClientContext context), {
+    void onAcceptingConnections(),
+  }) {
     final serviceHandlers = {
       '/_ah/start': _start,
       '/_ah/health': _health,
@@ -46,6 +49,9 @@ class AppEngineHttpServer {
     HttpServer.bind(_hostname, _port, shared: _shared)
         .then((HttpServer server) {
       _httpServer = server;
+      if (onAcceptingConnections != null) {
+        onAcceptingConnections();
+      }
 
       server.listen((HttpRequest request) {
         // Default handling is sending the request to the application.

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -38,7 +38,7 @@ class AppEngineHttpServer {
 
   void run(
     applicationHandler(HttpRequest request, ClientContext context), {
-    void onAcceptingConnections(),
+    void onAcceptingConnections(InternetAddress address, int port),
   }) {
     final serviceHandlers = {
       '/_ah/start': _start,
@@ -50,7 +50,7 @@ class AppEngineHttpServer {
         .then((HttpServer server) {
       _httpServer = server;
       if (onAcceptingConnections != null) {
-        onAcceptingConnections();
+        onAcceptingConnections(server.address, server.port);
       }
 
       server.listen((HttpRequest request) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.7.2
+version: 0.7.3
 author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine


### PR DESCRIPTION
This adds an optional `onAcceptingConnections` argument
to `runAppEngine`. If specified, it will be notified when
the server is ready to accept connections.