### PR TITLE
Add 'ClientContext.applicationContext` getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+
+ * Add `applicationContext` getter to `ClientContext`
+
 ## 0.7.3
 
  * Add `onAcceptingConnections` callback to `runAppEngine()`

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -13,6 +13,7 @@ import 'src/appengine_internal.dart' as appengine_internal;
 import 'src/client_context.dart';
 
 export 'package:gcloud/http.dart';
+export 'src/appengine_context.dart';
 export 'src/client_context.dart';
 export 'src/errors.dart';
 export 'src/logging.dart';

--- a/lib/src/appengine_context.dart
+++ b/lib/src/appengine_context.dart
@@ -4,7 +4,7 @@
 
 library appengine.appengine_context;
 
-class AppengineContext {
+class AppEngineContext {
   final String applicationID;
   final String partition;
   final String version;
@@ -13,7 +13,7 @@ class AppengineContext {
   final String instanceId;
   final bool isDevelopmentEnvironment;
 
-  AppengineContext(
+  AppEngineContext(
       this.isDevelopmentEnvironment,
       this.applicationID,
       this.version,

--- a/lib/src/appengine_internal.dart
+++ b/lib/src/appengine_internal.dart
@@ -171,7 +171,7 @@ Future<ContextRegistry> _initializeAppEngine() async {
 
   final instanceId = await _getInstanceid();
 
-  final context = AppengineContext(isDevEnvironment, projectId, versionId,
+  final context = AppEngineContext(isDevEnvironment, projectId, versionId,
       serviceId, instance, instanceId, pubServeUrl);
 
   final loggerFactory = await _obtainLoggerFactory(context, gcloudKey, zoneId);
@@ -239,7 +239,7 @@ Future<storage.Storage> _obtainStorageService(
 /// The underlying logging implementation will be usable within the current
 /// service scope.
 Future<LoggerFactory> _obtainLoggerFactory(
-    AppengineContext context, String gcloudKey, String zoneId) async {
+    AppEngineContext context, String gcloudKey, String zoneId) async {
   if (context.isDevelopmentEnvironment) {
     return StderrLoggerFactory();
   } else {

--- a/lib/src/client_context.dart
+++ b/lib/src/client_context.dart
@@ -7,6 +7,7 @@ library appengine.client_context;
 import 'package:gcloud/db.dart';
 import 'package:gcloud/storage.dart';
 
+import 'appengine_context.dart';
 import 'logging.dart';
 
 abstract class ClientContext {
@@ -19,6 +20,8 @@ abstract class ClientContext {
   bool get isProductionEnvironment;
 
   Services get services;
+
+  AppEngineContext get applicationContext;
 
   /// The `TRACE_ID` value from the `X-Cloud-Trace-Context` request header.
   ///

--- a/lib/src/server/context_registry.dart
+++ b/lib/src/server/context_registry.dart
@@ -31,7 +31,7 @@ class ContextRegistry {
   final LoggerFactory _loggingFactory;
   final db.DatastoreDB _db;
   final storage.Storage _storage;
-  final AppengineContext _appengineContext;
+  final AppEngineContext _appengineContext;
 
   final Map<HttpRequest, ClientContext> _request2context = {};
 
@@ -51,8 +51,7 @@ class ContextRegistry {
     }
 
     final services = _getServices(request, traceId);
-    final context = _ClientContextImpl(
-        services, _appengineContext.isDevelopmentEnvironment, traceId);
+    final context = _ClientContextImpl(services, _appengineContext, traceId);
     _request2context[request] = context;
 
     request.response.done.whenComplete(() {
@@ -113,12 +112,19 @@ class ContextRegistry {
 }
 
 class _ClientContextImpl implements ClientContext {
+  _ClientContextImpl(this.services, this.applicationContext, this.traceId);
+
+  @override
   final Services services;
-  final bool isDevelopmentEnvironment;
+
+  @override
+  final AppEngineContext applicationContext;
+
+  @override
   final String traceId;
 
-  _ClientContextImpl(
-      this.services, this.isDevelopmentEnvironment, this.traceId);
+  @override
+  bool get isDevelopmentEnvironment => applicationContext.isDevelopmentEnvironment;
 
   @override
   bool get isProductionEnvironment => !isDevelopmentEnvironment;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.7.3
+version: 0.8.0
 author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine


### PR DESCRIPTION
The application context class holds useful information,
such as the app id, version, etc. Currently, there's no
way to get at this information, as it's not exposed in
the `package:appengine`  API.  This PR exposes it via
the `ClientContext` API.

The use case is apps that run different versions or
project instances need a way to get that info. In the
case of the Flutter dashboard backend, it needs  to
construct a serialized proto containing the app id.