### PR TITLE
Instantiate new DatastoreDB for each request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+ * Instantiate new `DatastoreDB` instances for each request.
+
 ## 0.8.1
 
  * Detect dev mode when running behind a proxy.

--- a/lib/src/server/context_registry.dart
+++ b/lib/src/server/context_registry.dart
@@ -27,16 +27,21 @@ abstract class LoggerFactory {
   Logging newBackgroundLogger();
 }
 
+/// Interface for classes capable of vending instances of [db.DatastoreDB].
+abstract class DatastoreDBFactory {
+  db.DatastoreDB newDatastoreDB();
+}
+
 class ContextRegistry {
   final LoggerFactory _loggingFactory;
-  final db.DatastoreDB _db;
+  final DatastoreDBFactory _dbFactory;
   final storage.Storage _storage;
   final AppEngineContext _appengineContext;
 
   final Map<HttpRequest, ClientContext> _request2context = {};
 
-  ContextRegistry(
-      this._loggingFactory, this._db, this._storage, this._appengineContext);
+  ContextRegistry(this._loggingFactory, this._dbFactory, this._storage,
+      this._appengineContext);
 
   bool get isDevelopmentEnvironment {
     return _appengineContext.isDevelopmentEnvironment;
@@ -107,7 +112,7 @@ class ContextRegistry {
       loggingService = _loggingFactory.newBackgroundLogger();
     }
 
-    return Services(_db, _storage, loggingService);
+    return Services(_dbFactory.newDatastoreDB(), _storage, loggingService);
   }
 }
 
@@ -124,7 +129,8 @@ class _ClientContextImpl implements ClientContext {
   final String traceId;
 
   @override
-  bool get isDevelopmentEnvironment => applicationContext.isDevelopmentEnvironment;
+  bool get isDevelopmentEnvironment =>
+      applicationContext.isDevelopmentEnvironment;
 
   @override
   bool get isProductionEnvironment => !isDevelopmentEnvironment;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.8.1
+version: 0.9.0
 author: Dart Team <misc@dartlang.org>
 description: Support for using Dart as a custom runtime on Google App Engine Flexible Environment
 homepage: https://github.com/dart-lang/appengine


### PR DESCRIPTION
Before this change, servers that used DatastroeDB were succeptible to
concurrency issues, where different concurrentrequests would share the
same DatastoreDB instance. Specifically, the issue was as follows:

appengine registers a single gcloud:DatastoreDB instance upon server startup
 ↳ gcloud:DatastoreDB maintains a reference to a gcloud:Datastore
   (implemented by appengine:GrpcDatastoreImpl)
 ↳ appengine:GrpcDatastoreImpl maintains a reference to grpc:ClientChannel
 ↳ grpc:ClientChannel maintains a reference to an grpc:Http2ClientConnection
 ↳ grpc:Http2ClientConnection maintains state

This would cause issues whereby the client connection would throw for request
B because it would think that it was in a closing statedue to a call from
request A.

To fix this, this change ensires that each request gets a new instance
of DatastoreDB.

This is a breaking change because it changes the interface of the
`ContextRegistry` constructor.