### PR TITLE
Add level for errors

### DIFF
--- a/example/bin/server.dart
+++ b/example/bin/server.dart
@@ -38,7 +38,7 @@ requestHandler(HttpRequest request) {
     // This will log the message to stackdriver logging along with the error
     // and stack trace. This will also send error and stack trace to stackdriver
     // error reporting service.
-    _log.warning('bad thing happend', e, st);
+    _log.severe('a bad thing happend', e, st);
   }
 
   // Respond hello world, when serving normal traffic.

--- a/lib/appengine.dart
+++ b/lib/appengine.dart
@@ -158,6 +158,12 @@ ClientContext get context => ss.lookup(_APPENGINE_CONTEXT);
 
 /// Will register for log events produced by `package:logging` and forwards
 /// log records to the AppEngine logging service.
+///
+/// Errors and exceptions logged with a stacktrace and severity `severe` or
+/// higher will also be reported to [Stackdriver Error Reporting][1] when
+/// running on AppEngine.
+///
+/// [1]: https://cloud.google.com/error-reporting/
 void useLoggingPackageAdaptor() {
   appengine_internal.useLoggingPackageAdaptor();
 }

--- a/lib/src/grpc_api_impl/logging_impl.dart
+++ b/lib/src/grpc_api_impl/logging_impl.dart
@@ -124,11 +124,13 @@ class GrpcRequestLoggingImpl extends LoggingImpl {
   }
 
   @override
-  void reportError(Object error, StackTrace stackTrace, {DateTime timestamp}) {
+  void reportError(LogLevel level, Object error, StackTrace stackTrace,
+      {DateTime timestamp}) {
     if (stackTrace == null) {
-      super.reportError(error, stackTrace, timestamp: timestamp);
+      super.reportError(level, error, stackTrace, timestamp: timestamp);
       return;
     }
+    final api.LogSeverity severity = _severityFromLogLevel(level);
     error ??= 'unknown error';
     timestamp ??= DateTime.now();
 
@@ -143,7 +145,7 @@ class GrpcRequestLoggingImpl extends LoggingImpl {
       ..textPayload = _formatStackTrace(error, stackTrace)
       ..resource = gaeResource
       ..timestamp = nowTimestamp
-      ..severity = api.LogSeverity.ERROR
+      ..severity = severity
       // Write to stderr log, see:
       // https://cloud.google.com/error-reporting/docs/setup/app-engine-flexible-environment
       ..logName = _sharedLoggingService.backgroundLogName;
@@ -264,11 +266,13 @@ class GrpcBackgroundLoggingImpl extends Logging {
   }
 
   @override
-  void reportError(Object error, StackTrace stackTrace, {DateTime timestamp}) {
+  void reportError(LogLevel level, Object error, StackTrace stackTrace,
+      {DateTime timestamp}) {
     if (stackTrace == null) {
-      super.reportError(error, stackTrace, timestamp: timestamp);
+      super.reportError(level, error, stackTrace, timestamp: timestamp);
       return;
     }
+    final api.LogSeverity severity = _severityFromLogLevel(level);
     error ??= 'unknown error';
     timestamp ??= DateTime.now();
 
@@ -283,7 +287,7 @@ class GrpcBackgroundLoggingImpl extends Logging {
       ..textPayload = _formatStackTrace(error, stackTrace)
       ..resource = gaeResource
       ..timestamp = nowTimestamp
-      ..severity = api.LogSeverity.ERROR
+      ..severity = severity
       // Write to stderr log, see:
       // https://cloud.google.com/error-reporting/docs/setup/app-engine-flexible-environment
       ..logName = _sharedLoggingService.backgroundLogName;

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -48,6 +48,9 @@ abstract class Logging {
   /// Report an error, may print the error to log or report it to stackdriver
   /// error reporting if [stackTrace] is given and running on appengine, not
   /// localhost.
+  ///
+  /// Notice that Stackdriver Error Reporting only collects errors if [level] is
+  /// either [LogLevel.ERROR] or [LogLevel.CRITICAL].
   void reportError(
     LogLevel level,
     Object error,

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -48,8 +48,13 @@ abstract class Logging {
   /// Report an error, may print the error to log or report it to stackdriver
   /// error reporting if [stackTrace] is given and running on appengine, not
   /// localhost.
-  void reportError(Object error, StackTrace stackTrace, {DateTime timestamp}) {
-    log(LogLevel.ERROR, 'Error: $error\n$stackTrace', timestamp: timestamp);
+  void reportError(
+    LogLevel level,
+    Object error,
+    StackTrace stackTrace, {
+    DateTime timestamp,
+  }) {
+    log(level, 'Error: $error\n$stackTrace', timestamp: timestamp);
   }
 
   void log(

--- a/lib/src/server/logging_package_adaptor.dart
+++ b/lib/src/server/logging_package_adaptor.dart
@@ -57,7 +57,7 @@ void setupAppEngineLogging() {
             timestamp: record.time,
           );
           if (record.error != null && record.stackTrace != null) {
-            logging.reportError(record.error, record.stackTrace);
+            logging.reportError(level, record.error, record.stackTrace);
           }
         }
       }


### PR DESCRIPTION
Sorry, for stream of nit PRs... I just realized that I forgot to run tests that require credentials locally.
And those apparently broke.. It also indicated to me that maybe we should have severity level sent to stackdriver.

It only seems to consume severity level `ERROR` (and presumably `CRITICAL`), but that also seems fine.

Tests using datastore credentials also pass now :)

-----

I'll publish tomorrow if I don't find anymore nits... I tested it out on the staging site for `pub.dev`, where I'm pretty excited to be using this.