### PR TITLE
Implement `onConnectionStateChanged` to sync grpc upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.4
+
+* Implement `onConnectionStateChanged` to sync `grpc: 3.1.0`
+
 ## 0.13.3
 
 * Populate the pubspec `repository` field.

--- a/lib/src/appengine_internal.dart
+++ b/lib/src/appengine_internal.dart
@@ -327,6 +327,9 @@ class _ClientChannelWithClientId implements grpc.ClientChannel {
 
   @override
   Future<void> terminate() => _clientChannel.terminate();
+
+  @override
+  Stream<ConnectionState> get onConnectionStateChanged => _clientChannel.onConnectionStateChanged;
 }
 
 Future<String?> _getZoneInProduction() => _getMetadataValue('zone');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.13.3
+version: 0.13.4
 description: >
   Support for using Dart as a custom runtime on Google App Engine Flexible
   Environment
@@ -12,7 +12,7 @@ dependencies:
   fixnum: ^1.0.0
   gcloud: ^0.8.0
   googleapis_auth: ^1.1.0
-  grpc: ^3.0.0
+  grpc: ^3.1.0
   http: ^0.13.3
   logging: ^1.0.1
   path: ^1.8.0


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/appengine/issues/154