### PR TITLE
Prepare 0.13.6 with retries for datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.6-wip
 
 * Require Dart 2.19.
+* Setup `dbService` to do retries for failed requests.
 
 ## 0.13.5
 

--- a/lib/src/appengine_internal.dart
+++ b/lib/src/appengine_internal.dart
@@ -226,8 +226,13 @@ Future<db.DatastoreDB> _obtainDatastoreService(
     grpc_datastore_impl.OAuth2Scopes,
   );
   final grpcClient = _getGrpcClientChannel(endpoint, needAuthorization);
-  final rawDatastore = grpc_datastore_impl.GrpcDatastoreImpl(
-      grpcClient, authenticator, projectId);
+  final rawDatastore = datastore.Datastore.withRetry(
+    grpc_datastore_impl.GrpcDatastoreImpl(
+      grpcClient,
+      authenticator,
+      projectId,
+    ),
+  );
   return db.DatastoreDB(rawDatastore, modelDB: db.ModelDBImpl());
 }
 
@@ -329,7 +334,8 @@ class _ClientChannelWithClientId implements grpc.ClientChannel {
   Future<void> terminate() => _clientChannel.terminate();
 
   @override
-  Stream<ConnectionState> get onConnectionStateChanged => _clientChannel.onConnectionStateChanged;
+  Stream<ConnectionState> get onConnectionStateChanged =>
+      _clientChannel.onConnectionStateChanged;
 }
 
 Future<String?> _getZoneInProduction() => _getMetadataValue('zone');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.13.6-wip
+version: 0.13.6
 description: >
   Support for using Dart as a custom runtime on Google App Engine Flexible
   Environment
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   fixnum: ^1.0.0
-  gcloud: ^0.8.0
+  gcloud: ^0.8.10
   googleapis_auth: ^1.1.0
   grpc: ^3.1.0
   http: ^0.13.3


### PR DESCRIPTION
Previously we've sort of neglected retries or left it to the application.

But it's increasingly evident that with the `Query.run()` abstraction returning a `Stream`, it's not really possibly to reliably retry queries in the application, it has to be done when we make requests.


cc @isoos 
